### PR TITLE
bugfix for gitbook-plugin-github-issue-feedback install error.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,7 @@ ls -al
 cp -rf $BOOK_DIR/* /gitbook/
 cd /gitbook
 npm i colors@1.4.0 # for fixing gitbook-plugin-anchor-navigation-ex dependency issue (issue#3)
+npm i gitbook-plugin-github-issue-feedback # workaround for gitbook-plugin-github-issue-feedback error (issue#4)
 cd -
 sh /root/custom-entrypoint.sh "gitbook init && gitbook install && gitbook build"
 checkIfErr


### PR DESCRIPTION
Pre-install the `gitbook-plugin-github-issue-feedback` plug-in to fix the build error in [sysprog21/cpumemory-zhtw](https://github.com/sysprog21/cpumemory-zhtw/actions/runs/9699958361/job/26770762968).

Tested successfully in the Github action run of the forked repo/branch: [LawrenceHwang/cpumemory-zhtw/actions/runs/9707754852/job/26793478122](https://github.com/LawrenceHwang/cpumemory-zhtw/actions/runs/9707754852/job/26793478122)